### PR TITLE
Use Proxy2 (from purescript-proxy) instead of FProxy

### DIFF
--- a/generated-docs/Data/Smash.md
+++ b/generated-docs/Data/Smash.md
@@ -41,16 +41,16 @@ Construct a value of type `Smash ()` by lifting a value of type `a`.
 #### `singleton`
 
 ``` purescript
-singleton :: forall l r f a. IsSymbol l => RowCons l (FProxy f) () r => SProxy l -> f a -> Smash r a
+singleton :: forall l r f a. IsSymbol l => RowCons l (Proxy2 f) () r => SProxy l -> f a -> Smash r a
 ```
 
-Construct a value of type `Smash (l :: FProxy f)` by lifting a value
+Construct a value of type `Smash (l :: Proxy2 f)` by lifting a value
 of type `f a`.
 
 #### `cons`
 
 ``` purescript
-cons :: forall l f r1 r2 a b c. IsSymbol l => RowCons l (FProxy f) r1 r2 => SProxy l -> (a -> b -> c) -> f a -> Smash r1 b -> Smash r2 c
+cons :: forall l f r1 r2 a b c. IsSymbol l => RowCons l (Proxy2 f) r1 r2 => SProxy l -> (a -> b -> c) -> f a -> Smash r1 b -> Smash r2 c
 ```
 
 Add an interpreter of type `f a` to form a larger `Smash` product of
@@ -59,13 +59,13 @@ interpreters.
 #### `uncons`
 
 ``` purescript
-uncons :: forall l f r rest a. IsSymbol l => RowCons l (FProxy f) rest r => SProxy l -> Smash r a -> Exists (Uncons f rest a)
+uncons :: forall l f r rest a. IsSymbol l => RowCons l (Proxy2 f) rest r => SProxy l -> Smash r a -> Exists (Uncons f rest a)
 ```
 
 #### `lower`
 
 ``` purescript
-lower :: forall l f r rl rest a. IsSymbol l => Functor f => RowCons l (FProxy f) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Smash r a -> f a
+lower :: forall l f r rl rest a. IsSymbol l => Functor f => RowCons l (Proxy2 f) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Smash r a -> f a
 ```
 
 Project out the interpreter at the specified label, ignoring the future
@@ -83,7 +83,7 @@ returns records.
 #### `cosmash`
 
 ``` purescript
-cosmash :: forall l f r rest rl a. IsSymbol l => RowCons l (FProxy f) rest r => Functor f => RowToList rest rl => ComonadSmash rl rest => SProxy l -> (forall x. f (a -> x) -> x) -> Co (Smash r) a
+cosmash :: forall l f r rest rl a. IsSymbol l => RowCons l (Proxy2 f) rest r => Functor f => RowToList rest rl => ComonadSmash rl rest => SProxy l -> (forall x. f (a -> x) -> x) -> Co (Smash r) a
 ```
 
 A helper function for constructing actions in a `Co` monad.
@@ -91,26 +91,10 @@ A helper function for constructing actions in a `Co` monad.
 #### `cosmash_`
 
 ``` purescript
-cosmash_ :: forall l f r rest rl. IsSymbol l => RowCons l (FProxy f) rest r => Functor f => RowToList rest rl => ComonadSmash rl rest => SProxy l -> (forall x. f x -> x) -> Co (Smash r) Unit
+cosmash_ :: forall l f r rest rl. IsSymbol l => RowCons l (Proxy2 f) rest r => Functor f => RowToList rest rl => ComonadSmash rl rest => SProxy l -> (forall x. f x -> x) -> Co (Smash r) Unit
 ```
 
 A simpler variant of `cosmash` for when you don't care about the result.
-
-#### `FProxy`
-
-``` purescript
-data FProxy (f :: Type -> Type)
-  = FProxy
-```
-
-A value-level representation of a functor, so that we can use
-some mono-kinded compiler-provided machinery like `RowCons`.
-
-##### Instances
-``` purescript
-(Extend f, IsSymbol l, RowCons l (FProxy f) r1 r, ExtendSmash rl r1) => ExtendSmash (Cons l (FProxy f) rl) r
-(Comonad f, IsSymbol l, RowCons l (FProxy f) r1 r, ComonadSmash rl r1) => ComonadSmash (Cons l (FProxy f) rl) r
-```
 
 #### `Uncons`
 
@@ -131,7 +115,7 @@ class Smashed rl interpreters proxies results | rl -> interpreters proxies resul
 ##### Instances
 ``` purescript
 Smashed Nil () () ()
-(IsSymbol l, RowLacks l results_, RowLacks l interpreters_, RowLacks l proxies_, RowCons l (f a) interpreters_ interpreters, RowCons l (FProxy f) proxies_ proxies, RowCons l a results_ results, Smashed rl interpreters_ proxies_ results_) => Smashed (Cons l (f a) rl) interpreters proxies results
+(IsSymbol l, RowLacks l results_, RowLacks l interpreters_, RowLacks l proxies_, RowCons l (f a) interpreters_ interpreters, RowCons l (Proxy2 f) proxies_ proxies, RowCons l a results_ results, Smashed rl interpreters_ proxies_ results_) => Smashed (Cons l (f a) rl) interpreters proxies results
 ```
 
 #### `ExtendSmash`
@@ -144,7 +128,7 @@ class ExtendSmash rl r | rl -> r where
 ##### Instances
 ``` purescript
 ExtendSmash Nil ()
-(Extend f, IsSymbol l, RowCons l (FProxy f) r1 r, ExtendSmash rl r1) => ExtendSmash (Cons l (FProxy f) rl) r
+(Extend f, IsSymbol l, RowCons l (Proxy2 f) r1 r, ExtendSmash rl r1) => ExtendSmash (Cons l (Proxy2 f) rl) r
 ```
 
 #### `ComonadSmash`
@@ -157,7 +141,7 @@ class (ExtendSmash rl r) <= ComonadSmash rl r | rl -> r where
 ##### Instances
 ``` purescript
 ComonadSmash Nil ()
-(Comonad f, IsSymbol l, RowCons l (FProxy f) r1 r, ComonadSmash rl r1) => ComonadSmash (Cons l (FProxy f) rl) r
+(Comonad f, IsSymbol l, RowCons l (Proxy2 f) r1 r, ComonadSmash rl r1) => ComonadSmash (Cons l (Proxy2 f) rl) r
 ```
 
 

--- a/generated-docs/Data/Smash/Cofree.md
+++ b/generated-docs/Data/Smash/Cofree.md
@@ -3,13 +3,13 @@
 #### `lift`
 
 ``` purescript
-lift :: forall f r rl a. RowToList r rl => Functor f => ComonadSmash rl r => Co f a -> Co (Smash (cofree :: FProxy (Cofree f) | r)) a
+lift :: forall f r rl a. RowToList r rl => Functor f => ComonadSmash rl r => Co f a -> Co (Smash (cofree :: Proxy2 (Cofree f) | r)) a
 ```
 
 #### `liftWith`
 
 ``` purescript
-liftWith :: forall l f r rl rest a. IsSymbol l => Functor f => RowCons l (FProxy (Cofree f)) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co f a -> Co (Smash r) a
+liftWith :: forall l f r rl rest a. IsSymbol l => Functor f => RowCons l (Proxy2 (Cofree f)) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co f a -> Co (Smash r) a
 ```
 
 

--- a/generated-docs/Data/Smash/Env.md
+++ b/generated-docs/Data/Smash/Env.md
@@ -3,13 +3,13 @@
 #### `ask`
 
 ``` purescript
-ask :: forall w r rl a. ComonadEnv a w => RowToList r rl => ComonadSmash rl r => Co (Smash (env :: FProxy w | r)) a
+ask :: forall w r rl a. ComonadEnv a w => RowToList r rl => ComonadSmash rl r => Co (Smash (env :: Proxy2 w | r)) a
 ```
 
 #### `askWith`
 
 ``` purescript
-askWith :: forall l w r rl rest a. ComonadEnv a w => IsSymbol l => RowCons l (FProxy w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co (Smash r) a
+askWith :: forall l w r rl rest a. ComonadEnv a w => IsSymbol l => RowCons l (Proxy2 w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co (Smash r) a
 ```
 
 

--- a/generated-docs/Data/Smash/Lens.md
+++ b/generated-docs/Data/Smash/Lens.md
@@ -3,7 +3,7 @@
 #### `label`
 
 ``` purescript
-label :: forall l s t a b rest. IsSymbol l => Functor b => RowCons l (FProxy a) rest s => RowCons l (FProxy b) rest t => SProxy l -> Lens (Smash s) (Smash t) a b
+label :: forall l s t a b rest. IsSymbol l => Functor b => RowCons l (Proxy2 a) rest s => RowCons l (Proxy2 b) rest t => SProxy l -> Lens (Smash s) (Smash t) a b
 ```
 
 A `Lens` which focuses on the specified label in a `Smash` product.

--- a/generated-docs/Data/Smash/Store.md
+++ b/generated-docs/Data/Smash/Store.md
@@ -3,25 +3,25 @@
 #### `get`
 
 ``` purescript
-get :: forall w r rl a. ComonadStore a w => RowToList r rl => ComonadSmash rl r => Co (Smash (store :: FProxy w | r)) a
+get :: forall w r rl a. ComonadStore a w => RowToList r rl => ComonadSmash rl r => Co (Smash (store :: Proxy2 w | r)) a
 ```
 
 #### `getWith`
 
 ``` purescript
-getWith :: forall l w r rl rest a. ComonadStore a w => IsSymbol l => RowCons l (FProxy w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co (Smash r) a
+getWith :: forall l w r rl rest a. ComonadStore a w => IsSymbol l => RowCons l (Proxy2 w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> Co (Smash r) a
 ```
 
 #### `put`
 
 ``` purescript
-put :: forall w r rl a. ComonadStore a w => RowToList r rl => ComonadSmash rl r => a -> Co (Smash (store :: FProxy w | r)) Unit
+put :: forall w r rl a. ComonadStore a w => RowToList r rl => ComonadSmash rl r => a -> Co (Smash (store :: Proxy2 w | r)) Unit
 ```
 
 #### `putWith`
 
 ``` purescript
-putWith :: forall l w r rl rest a. ComonadStore a w => IsSymbol l => RowCons l (FProxy w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> a -> Co (Smash r) Unit
+putWith :: forall l w r rl rest a. ComonadStore a w => IsSymbol l => RowCons l (Proxy2 w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> a -> Co (Smash r) Unit
 ```
 
 

--- a/generated-docs/Data/Smash/Traced.md
+++ b/generated-docs/Data/Smash/Traced.md
@@ -3,13 +3,13 @@
 #### `tell`
 
 ``` purescript
-tell :: forall w r rl a. ComonadTraced a w => RowToList r rl => ComonadSmash rl r => a -> Co (Smash (traced :: FProxy w | r)) Unit
+tell :: forall w r rl a. ComonadTraced a w => RowToList r rl => ComonadSmash rl r => a -> Co (Smash (traced :: Proxy2 w | r)) Unit
 ```
 
 #### `tellWith`
 
 ``` purescript
-tellWith :: forall l w r rl rest a. ComonadTraced a w => IsSymbol l => RowCons l (FProxy w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> a -> Co (Smash r) Unit
+tellWith :: forall l w r rl rest a. ComonadTraced a w => IsSymbol l => RowCons l (Proxy2 w) rest r => RowToList rest rl => ComonadSmash rl rest => SProxy l -> a -> Co (Smash r) Unit
 ```
 
 

--- a/src/Data/Smash/Cofree.purs
+++ b/src/Data/Smash/Cofree.purs
@@ -10,13 +10,14 @@ import Control.Comonad.Cofree (Cofree, tail)
 import Data.Functor.Pairing.Co (Co, runCo)
 import Data.Smash as S
 import Data.Symbol (class IsSymbol, SProxy(..))
+import Type.Proxy (Proxy2)
 import Type.Row (class RowToList)
 
 liftWith
   :: forall l f r rl rest a
    . IsSymbol l
   => Functor f
-  => RowCons l (S.FProxy (Cofree f)) rest r
+  => RowCons l (Proxy2 (Cofree f)) rest r
   => RowToList rest rl
   => S.ComonadSmash rl rest
   => SProxy l
@@ -30,5 +31,5 @@ lift
   => Functor f
   => S.ComonadSmash rl r
   => Co f a
-  -> Co (S.Smash (cofree :: S.FProxy (Cofree f) | r)) a
+  -> Co (S.Smash (cofree :: Proxy2 (Cofree f) | r)) a
 lift = liftWith (SProxy :: SProxy "cofree")

--- a/src/Data/Smash/Env.purs
+++ b/src/Data/Smash/Env.purs
@@ -8,13 +8,14 @@ import Control.Comonad.Env.Class as Env
 import Data.Functor.Pairing.Co (Co)
 import Data.Smash as S
 import Data.Symbol (class IsSymbol, SProxy(..))
+import Type.Proxy (Proxy2)
 import Type.Row (class RowToList)
 
 askWith
   :: forall l w r rl rest a
    . Env.ComonadEnv a w
   => IsSymbol l
-  => RowCons l (S.FProxy w) rest r
+  => RowCons l (Proxy2 w) rest r
   => RowToList rest rl
   => S.ComonadSmash rl rest
   => SProxy l
@@ -26,5 +27,5 @@ ask
    . Env.ComonadEnv a w
   => RowToList r rl
   => S.ComonadSmash rl r
-  => Co (S.Smash (env :: S.FProxy w | r)) a
+  => Co (S.Smash (env :: Proxy2 w | r)) a
 ask = askWith (SProxy :: SProxy "env")

--- a/src/Data/Smash/Lens.purs
+++ b/src/Data/Smash/Lens.purs
@@ -14,16 +14,17 @@ import Data.Functor.Day.Hom (Hom, hom)
 import Data.Functor.Day.Profunctor (class Profunctor, class Strong, Lens, Optic, lens)
 import Data.Functor.Pairing.Co (Co, co, runCo)
 import Data.Identity (Identity)
-import Data.Smash (FProxy, Smash, Uncons(..), cons, uncons)
+import Data.Smash (Smash, Uncons(..), cons, uncons)
 import Data.Symbol (class IsSymbol, SProxy)
+import Type.Proxy (Proxy2)
 
 -- | A `Lens` which focuses on the specified label in a `Smash` product.
 label
   :: forall l s t a b rest
    . IsSymbol l
   => Functor b
-  => RowCons l (FProxy a) rest s
-  => RowCons l (FProxy b) rest t
+  => RowCons l (Proxy2 a) rest s
+  => RowCons l (Proxy2 b) rest t
   => SProxy l
   -> Lens (Smash s) (Smash t) a b
 label l = lens \s -> runExists go (uncons l s) where

--- a/src/Data/Smash/Store.purs
+++ b/src/Data/Smash/Store.purs
@@ -12,13 +12,14 @@ import Control.Comonad.Store.Class (class ComonadStore, pos, peek)
 import Data.Functor.Pairing.Co (Co)
 import Data.Smash as S
 import Data.Symbol (class IsSymbol, SProxy(..))
+import Type.Proxy (Proxy2)
 import Type.Row (class RowToList)
 
 getWith
   :: forall l w r rl rest a
    . ComonadStore a w
   => IsSymbol l
-  => RowCons l (S.FProxy w) rest r
+  => RowCons l (Proxy2 w) rest r
   => RowToList rest rl
   => S.ComonadSmash rl rest
   => SProxy l
@@ -30,14 +31,14 @@ get
    . ComonadStore a w
   => RowToList r rl
   => S.ComonadSmash rl r
-  => Co (S.Smash (store :: S.FProxy w | r)) a
+  => Co (S.Smash (store :: Proxy2 w | r)) a
 get = getWith (SProxy :: SProxy "store")
 
 putWith
   :: forall l w r rl rest a
    . ComonadStore a w
   => IsSymbol l
-  => RowCons l (S.FProxy w) rest r
+  => RowCons l (Proxy2 w) rest r
   => RowToList rest rl
   => S.ComonadSmash rl rest
   => SProxy l
@@ -51,5 +52,5 @@ put
   => RowToList r rl
   => S.ComonadSmash rl r
   => a
-  -> Co (S.Smash (store :: S.FProxy w | r)) Unit
+  -> Co (S.Smash (store :: Proxy2 w | r)) Unit
 put = putWith (SProxy :: SProxy "store")

--- a/src/Data/Smash/Traced.purs
+++ b/src/Data/Smash/Traced.purs
@@ -9,13 +9,14 @@ import Control.Comonad.Traced.Class (class ComonadTraced, track)
 import Data.Functor.Pairing.Co (Co)
 import Data.Smash as S
 import Data.Symbol (class IsSymbol, SProxy(..))
+import Type.Proxy (Proxy2)
 import Type.Row (class RowToList)
 
 tellWith
   :: forall l w r rl rest a
    . ComonadTraced a w
   => IsSymbol l
-  => RowCons l (S.FProxy w) rest r
+  => RowCons l (Proxy2 w) rest r
   => RowToList rest rl
   => S.ComonadSmash rl rest
   => SProxy l
@@ -29,5 +30,5 @@ tell
   => RowToList r rl
   => S.ComonadSmash rl r
   => a
-  -> Co (S.Smash (traced :: S.FProxy w | r)) Unit
+  -> Co (S.Smash (traced :: Proxy2 w | r)) Unit
 tell = tellWith (SProxy :: SProxy "traced")

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,10 +13,11 @@ import Data.Smash as S
 import Data.Smash.Env (ask)
 import Data.Smash.Store (get, put)
 import Data.Smash.Traced (tell)
+import Type.Proxy (Proxy2)
 
-script :: Co (S.Smash ( store :: S.FProxy (Store Int)
-                      , traced :: S.FProxy (Traced (Array String))
-                      , env :: S.FProxy (Env Boolean)
+script :: Co (S.Smash ( store :: Proxy2 (Store Int)
+                      , traced :: Proxy2 (Traced (Array String))
+                      , env :: Proxy2 (Env Boolean)
                       )) Unit
 script = do
   increment <- ask


### PR DESCRIPTION
The `FProxy (f :: Type -> Type)` type is already defined in purescript-proxy as `Proxy2`. This pull request removes the `FProxy` type definition and changes its every occurrence to `Proxy2`.

What do you think @paf31?